### PR TITLE
Added the ability to default answers not provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,11 @@ it must list the commands you will be able to use later. here you will give your
 
 With regards to the quick pick options, if you specify the values field in a question it will automatically be converted to quick pick prompt. The detail field of the values will be used when calling the command you have designated.
 
+If a user does not provide an answer for one of your questions it will default to `.`, but if you would like to specify something else, you just need to add `defaultAnswerValue` to your vus-config.json, see below. Spaces don't work so great when working with space sperated command line parameters ;)
+
 ```javascript
 {
+  "defaultAnswerValue": "-",
   "commands": [
     {
       "name": "addComponent",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,9 +6,10 @@ import { promptCommand } from './library/promptCommand';
 import { showInfoMessage } from './library/showInfoMessage';
 import { promptCommandQuestions } from './library/promptCommandQuestions';
 import { getTerminal } from './library/getTerminal';
+import { defaultAnswers } from './library/defaultAnswers';
 
 export function activate(context: vscode.ExtensionContext) {
-  let disposable = vscode.commands.registerCommand('extension.scriptUI', async fileInfo => {
+  let disposable = vscode.commands.registerCommand('extension.scriptUI', async (fileInfo: any) => {
     showInfoMessage('Loading configration...');
     const config = loadConfiguration(fileInfo);
 
@@ -19,7 +20,7 @@ export function activate(context: vscode.ExtensionContext) {
         console.log('answers', answers);
         const terminal = await getTerminal();
         if (terminal) {
-          terminal.sendText(`${command.command} ${config.locationContextDirectory} ${answers.join(' ')}`);
+          terminal.sendText(`${command.command} ${config.locationContextDirectory} ${defaultAnswers(config, answers).join(' ')}`);
         }
       }
     }

--- a/src/library/defaultAnswers.ts
+++ b/src/library/defaultAnswers.ts
@@ -1,0 +1,15 @@
+import { IConfig } from '../models/config';
+
+export function defaultAnswers(config: IConfig, answers: (string | undefined)[]) {
+	return answers.map((answer: string | undefined) => {
+		answer = typeof answer === 'string' ? answer.replace(/^\s*$/g, '') : answer;
+		switch (answer) {
+			case null:
+			case undefined:
+			case '':
+				return config.defaultAnswerValue || '.';
+			default:
+				return answer;
+		}
+	});
+}

--- a/src/library/promptCommandQuestions.ts
+++ b/src/library/promptCommandQuestions.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import { ICommand } from '../models/config';
 import { showInfoMessage } from './showInfoMessage';
 
-export async function promptCommandQuestions(command: ICommand) {
+export async function promptCommandQuestions(command: ICommand): Promise<(string | undefined)[]> {
   const answers = [];
 
   if (command && command.questions) {

--- a/src/models/config.ts
+++ b/src/models/config.ts
@@ -30,4 +30,5 @@ export interface IConfig {
   locationContext: string;
   locationContextDirectory: string;
   isLocationRoot: boolean;
+  defaultAnswerValue: string;
 }


### PR DESCRIPTION
The plugin would return an array with the length of the number of questions answered and not based on the number of questions - therefore when reading the questions in via the command line you are not guaranteed the answers will be ordered by the questions and that blank answers will be pulled in.